### PR TITLE
fix: no return if not `PRINT_LOG`

### DIFF
--- a/fastdeploy/utils/utils.cc
+++ b/fastdeploy/utils/utils.cc
@@ -37,8 +37,8 @@ FDLogger& FDLogger::operator<<(std::ostream& (*os)(std::ostream&)) {
   __android_log_print(ANDROID_LOG_INFO, prefix_.c_str(), "%s", line_.c_str());
 #endif
   line_ = "";
-  return *this;
 #endif
+  return *this;
 }
 
 bool ReadBinaryFromFile(const std::string& file, std::string* contents) {


### PR DESCRIPTION
如果是`-DPRINT_LOG=OFF`会导致没有返回值，进而导致`SIGTRAP`。 CC: @Cryolitia 